### PR TITLE
Enabled cross-building for scala 2.11 & 2.12; updated to use most recent akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,22 +2,23 @@ name := "Akka SMPP"
 
 organization := "akkasmpp"
 
-version := "0.3.0-SNAPSHOT"
+version := "0.4.0-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
+
+crossScalaVersions := Seq("2.11.9", "2.12.1")
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-
-val akkaV = "2.4.7"
+val akkaV = "2.5.0"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % akkaV,
-  "com.typesafe.akka" %% "akka-slf4j" % "2.3.10",
-  "com.cloudhopper" % "ch-commons-charset" % "3.0.2",
+  "com.typesafe.akka" %% "akka-slf4j" % akkaV,
   "com.typesafe.akka" %% "akka-testkit" % akkaV,
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.11.5" % "test"
+  "com.cloudhopper" % "ch-commons-charset" % "3.0.2",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
 )
 
 javacOptions in Compile ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-Xlint:deprecation")

--- a/src/main/scala/akkasmpp/demos/CliSmpp.scala
+++ b/src/main/scala/akkasmpp/demos/CliSmpp.scala
@@ -1,7 +1,7 @@
 package akkasmpp.demos
 
 import java.net.InetSocketAddress
-
+import scala.concurrent.Await
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
 import akka.stream.ActorMaterializer
@@ -10,7 +10,6 @@ import akkasmpp.actors.{SmppClient, SmppClientConfig}
 import akkasmpp.extensions.Smpp
 import akkasmpp.protocol._
 import akkasmpp.userdata.DefaultGsmCharset
-
 import scala.concurrent.duration._
 
 /**
@@ -106,7 +105,9 @@ object CliSmpp extends App {
       println("shutting down...")
       context.stop(self)
       mat.shutdown()
-      actorSystem.shutdown()
+      actorSystem.terminate()
+      import scala.concurrent.duration._
+      Await.result(actorSystem.whenTerminated, 30.seconds)
 
     }
   }))

--- a/src/test/scala/akkasmpp/EndToEndBindTest.scala
+++ b/src/test/scala/akkasmpp/EndToEndBindTest.scala
@@ -2,7 +2,6 @@ package akkasmpp
 
 import java.net.InetSocketAddress
 import javax.net.ssl.SSLContext
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
@@ -11,9 +10,8 @@ import akkasmpp.extensions.Smpp.ServerBinding
 import akkasmpp.protocol.{BindTransceiver, BindTransceiverResp, COctetString, CommandStatus, Pdu, PduBuilder}
 import akkasmpp.ssl.TlsContext
 import akkasmpp.testutil.ByteStringHelpers
-import org.scalatest.concurrent.AsyncAssertions
-import org.scalatest.{FlatSpec, Matchers, ShouldMatchers}
-
+import org.scalatest.concurrent.{AsyncAssertions, Waiters}
+import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.duration._
 
 /**
@@ -21,10 +19,9 @@ import scala.concurrent.duration._
   */
 class EndToEndBindTest
     extends FlatSpec
-    with ShouldMatchers
     with Matchers
     with ByteStringHelpers
-    with AsyncAssertions {
+    with Waiters {
 
   implicit val pc = new PatienceConfig(timeout = 2.seconds)
   implicit val as  = ActorSystem()

--- a/src/test/scala/akkasmpp/protocol/OctetStringTest.scala
+++ b/src/test/scala/akkasmpp/protocol/OctetStringTest.scala
@@ -2,9 +2,9 @@ package akkasmpp.protocol
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{FunSpec, ShouldMatchers}
+import org.scalatest.{FunSpec, Matchers}
 
-class OctetStringTest extends FunSpec with ShouldMatchers with GeneratorDrivenPropertyChecks {
+class OctetStringTest extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
 
   describe("OctetString") {
     it ("should pattern match empty") {

--- a/src/test/scala/akkasmpp/protocol/SmppPduFramingStageTest.scala
+++ b/src/test/scala/akkasmpp/protocol/SmppPduFramingStageTest.scala
@@ -5,15 +5,14 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
-import org.scalatest.{FunSuite, ShouldMatchers}
-
+import org.scalatest.{FunSuite, Matchers}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
   * akka stream tests
   */
-class SmppPduFramingStageTest extends FunSuite with ShouldMatchers {
+class SmppPduFramingStageTest extends FunSuite with Matchers {
 
   val testConfig = com.typesafe.config.ConfigFactory.parseString(
     """


### PR DESCRIPTION
I also bumped the version if it's OK with you.

I also couldn't find a published version and judging by the build.sbt it looks like users are supposed to do it manually. Do you mind publishing the library to bintray? If you don't have time or don't want to, are you OK with me publishing this under a different organization (or maybe you can suggest something else)?